### PR TITLE
cf ssh needs a PATH, add yum for RedHat

### DIFF
--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -121,6 +121,7 @@ install_dependencies () {
         --command 'source /etc/profile && (which git && which git-lfs && which curl) || \
                                (which apk && apk add git git-lfs curl) || \
                                (which apt-get && apt-get update && apt-get install -y git git-lfs curl) || \
+                               (which yum && yum install git git-lfs curl) || \
                                (echo "[cf-driver] Required packages missing and install attempt failed" && exit 1)'
 
     # gitlab-runner-helper includes a limited subset of gitlab-runner functionality

--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -117,10 +117,11 @@ install_dependencies () {
     # Of course, RedHat/UBI will need more help to add RPM repos with the correct
     # version. TODO - RedHat support
     echo "[cf-driver] Ensuring git, git-lfs, and curl are installed"
-    cf ssh "$container_id" -c '(which git && which git-lfs && which curl) || \
+    cf ssh "$container_id" --request-pseudo-tty \
+        --command 'source /etc/profile && (which git && which git-lfs && which curl) || \
                                (which apk && apk add git git-lfs curl) || \
                                (which apt-get && apt-get update && apt-get install -y git git-lfs curl) || \
-                               (echo "Required packages missing and I do not know what to do about it" && exit 1)'
+                               (echo "[cf-driver] Required packages missing and install attempt failed" && exit 1)'
 
     # gitlab-runner-helper includes a limited subset of gitlab-runner functionality
     # plus Git and Git-LFS. https://s3.dualstack.us-east-1.amazonaws.com/gitlab-runner-downloads/latest/index.html

--- a/runner/cf-driver/run.sh
+++ b/runner/cf-driver/run.sh
@@ -15,7 +15,7 @@ if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
     printf "\n=========\n[cf-driver] RUNNER_DEBUG: End command display\n"
 fi
 
-if ! cf ssh "$CONTAINER_ID" < "${1}"; then
+if ! cf ssh "$CONTAINER_ID" -c "source /etc/profile" < "${1}"; then
     # Exit using the variable, to make the build as failure in GitLab
     # CI.
     exit "$BUILD_FAILURE_EXIT_CODE"


### PR DESCRIPTION
This may address #9.

We should probably test by having Alpine, Debian and RedHat based worker images run, but that will be a later issue

