### PR TITLE
Add some newlines to the printf's in run.sh

### DIFF
--- a/runner/cf-driver/run.sh
+++ b/runner/cf-driver/run.sh
@@ -5,14 +5,14 @@
 currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${currentDir}/base.sh"
 
-printf "[cf-driver] Using SSH to connect to %s and run steps" "$CONTAINER_ID"
+printf "[cf-driver] Using SSH to connect to %s and run steps\n" "$CONTAINER_ID"
 
 if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
     # DANGER: There may be sensitive information in this output.
     # Generated job logs should be removed after this is used.
-    printf "[cf-driver] RUNNER_DEBUG: About to run the following:\n======"
+    printf "[cf-driver] RUNNER_DEBUG: About to run the following:\n=========\n"
     cat "$1"
-    printf "=========[cf-driver] RUNNER_DEBUG: End command display"
+    printf "\n=========\n[cf-driver] RUNNER_DEBUG: End command display\n"
 fi
 
 if ! cf ssh "$CONTAINER_ID" < "${1}"; then
@@ -21,4 +21,4 @@ if ! cf ssh "$CONTAINER_ID" < "${1}"; then
     exit "$BUILD_FAILURE_EXIT_CODE"
 fi
 
-printf "[cf-driver] Completed SSH session with %s to run steps" "$CONTAINER_ID"
+printf "[cf-driver] Completed SSH session with %s to run steps\n" "$CONTAINER_ID"


### PR DESCRIPTION
I wasn't sure why the `printf` here instead of echos? but `printf` doesn't add newlines which is a bit obscuring in the logs.