### PR TITLE
Push, Pull, Build, Bop Images

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -21,6 +21,8 @@ applications:
       # See gitlab-runner register --help for available vars
       CI_SERVER_TOKEN: ((ci_server_token))
       CI_SERVER_URL: ((ci_server_url))
+      DOCKER_HUB_USER: ((docker_hub_user))
+      DOCKER_HUB_TOKEN: ((docker_hub_token))
       RUNNER_EXECUTOR: ((runner_executor))
       RUNNER_NAME: ((runner_name))
       # Remaining runner configuration is generally static. In order to surface

--- a/runner/cf-driver/base.sh
+++ b/runner/cf-driver/base.sh
@@ -13,5 +13,10 @@ if [ -z "$DEFAULT_JOB_IMAGE" ]; then
     echo "WARNING: DEFAULT_JOB_IMAGE not set! Falling back to ${DEFAULT_JOB_IMAGE}"
 fi
 
+# Complain if no Docker Hub credentials so we aren't bad neighbors
+if [ -z "$DOCKER_HUB_USER" ] || [ -z "$DOCKER_HUB_TOKEN" ]; then
+    echo "WARNING: Docker Hub credentials not set! Falling back to public access which could result in rate limiting."
+fi
+
 # Use a custom image if provided, else fallback to configured default
 CUSTOM_ENV_CI_JOB_IMAGE="${CUSTOM_ENV_CI_JOB_IMAGE:=$DEFAULT_JOB_IMAGE}"

--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -63,9 +63,18 @@ start_service () {
         cf delete -f "$container_id"
     fi
 
-    # TODO - Figure out how to handle command and non-global memory definition
-    cf push "$container_id" --docker-image "$image_name" -m "$WORKER_MEMORY" \
-        --no-route --health-check-type process
+    if [ "$image_name" =~ "registry.gitlab.com" ]; then
+        CF_DOCKER_PASSWORD=$CUSTOM_ENV_CI_REGISTRY_PASSWORD \
+        cf push "$container_id" \
+            --docker-image "$image_name" \
+            --docker-username "$CUSTOM_ENV_CI_REGISTRY_USER" \
+            -m "$WORKER_MEMORY" --no-route --health-check-type process
+    else
+        # TODO - Figure out how to handle command and non-global memory definition
+        cf push "$container_id" \
+            --docker-image "$image_name" \
+            -m "$WORKER_MEMORY" --no-route --health-check-type process
+    fi
 
     cf map-route "$container_id" apps.internal --hostname "$container_id"
 }

--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -12,6 +12,7 @@ trap 'rm -f "$TMPVARFILE"' EXIT
 currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${currentDir}/base.sh" # Get variables from base.
 if [ -z "${WORKER_MEMORY-}" ]; then
+    # Some jobs may fail with less than 512M, e.g., `npm i`
     WORKER_MEMORY="512M"
 fi
 

--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -65,7 +65,7 @@ start_service () {
         '--no-route'
     )
 
-    if [ -n "$container_entrypoint" ]; then
+    if [ -n "$container_entrypoint" ] || [ -n "$container_command" ]; then
         push_args+=('-c' "${container_entrypoint[@]}" "${container_command[@]}")
     fi
 

--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -31,11 +31,22 @@ create_temporary_varfile () {
 get_registry_credentials () {
     image_name="$1"
 
+    # Note: the regex for non-docker image locations is not air-tight--
+    #       the definition for the format is a little loose, for one thing,
+    #       but this should work for most cases and can be revisited when
+    #       we're working with more a more robust set of language features
+    #       and can better parse the image name.
+
     if echo "$image_name" | grep -q "registry.gitlab.com"; then
+        # Detect GitLab CR and use provided environment to authenticate
         echo "$CUSTOM_ENV_CI_REGISTRY_USER" "$CUSTOM_ENV_CI_REGISTRY_PASSWORD"
+
     elif echo "$image_name" | grep -q -P '^(?!registry-\d+.docker.io)[\w-]+(?:\.[\w-]+)+'; then
+        # Detect non-Docker registry that we aren't supporting auth for yet
         return 0
+
     elif [ -n "$DOCKER_HUB_TOKEN" ] && [ -n "$DOCKER_HUB_USER" ]; then
+        # Default to Docker Hub credentials when available
         echo "$DOCKER_HUB_USER" "$DOCKER_HUB_TOKEN"
     fi
 }

--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -64,7 +64,7 @@ start_service () {
         cf delete -f "$container_id"
     fi
 
-    if [ "$image_name" =~ "registry.gitlab.com" ]; then
+    if [[ "$image_name" =~ "registry.gitlab.com" ]]; then
         CF_DOCKER_PASSWORD=$CUSTOM_ENV_CI_REGISTRY_PASSWORD \
         cf push "$container_id" \
             --docker-image "$image_name" \

--- a/runner/cf-driver/run.sh
+++ b/runner/cf-driver/run.sh
@@ -7,6 +7,9 @@ source "${currentDir}/base.sh"
 
 printf "[cf-driver] Using SSH to connect to %s and run steps\n" "$CONTAINER_ID"
 
+# Add line below script shebang to source the /etc/profile
+sed -i '2isource /etc/profile \n' $1
+
 if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
     # DANGER: There may be sensitive information in this output.
     # Generated job logs should be removed after this is used.
@@ -15,7 +18,7 @@ if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
     printf "\n=========\n[cf-driver] RUNNER_DEBUG: End command display\n"
 fi
 
-if ! cf ssh "$CONTAINER_ID" -c "source /etc/profile" < "${1}"; then
+if ! cf ssh "$CONTAINER_ID" < "${1}"; then
     # Exit using the variable, to make the build as failure in GitLab
     # CI.
     exit "$BUILD_FAILURE_EXIT_CODE"

--- a/vars.yml-example
+++ b/vars.yml-example
@@ -10,3 +10,5 @@ runner_memory: 512M
 worker_memory: 512M
 service_account_instance: my-service-account
 object_store_instance: my-brokered-bucket
+docker_hub_user: my-docker-user
+docker_hub_token: my-docker-token


### PR DESCRIPTION
The changes made to support the Kaniko service workflow are very moderate on the runner side, and mostly depend on the user doing some ugly stuff in their job. I figure we'll want to abstract some of this away for them at some point, but it probably makes more sense to do that after / during a rewrite (see #25 for details and a walkthrough of the script steps).

```yaml
package image:
  stage: package
  image: cloudfoundry/cli:8.7.10
  services:
    - name: gcr.io/kaniko-project/executor:debug
      alias: kaniko
      entrypoint: ["/busybox/sh"]
  script:
    - cf api https://api.fr.cloud.gov
    - cf auth $CLOUD_GOV_USER $CLOUD_GOV_PASS
    - cf target -o gsa-tts-devtools-prototyping -s zjr-gl-test
    - tar -C $CI_PROJECT_DIR -czf bundle.tar.gz .
    - ci_auth=$(echo -n $CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD | base64)
    - >-
      kaniko_cfg="{\"auths\": {\"${CI_REGISTRY}\": {\"auth\": \"${ci_auth}\"}}}"
    - >-
      echo $kaniko_cfg |
      cf ssh "${SERVICE_PREFIX}kaniko" --command
      "/busybox/cat > /kaniko/.docker/config.json"
    - >-
      cat bundle.tar.gz |
      cf ssh "${SERVICE_PREFIX}kaniko" --command
      "/kaniko/executor --context tar://stdin --destination=$APP_IMAGE_TAG"
```

Closes #16
Closes #17
Closes #21
Closes #22