### PR TITLE
fixing accidental deletion during previous rebase

### DIFF
--- a/runner/cf-driver/worker-manifest.yml
+++ b/runner/cf-driver/worker-manifest.yml
@@ -9,3 +9,4 @@ applications:
       RUNNER_BUILDS_DIR: "/tmp/build"
       RUNNER_CACHE_DIR: "/tmp/cache"
       CACHE_SHARED: "true"
+# Additional items may be added below this point in prepare.sh


### PR DESCRIPTION
I made a horrible mess trying to sign previously unsigned commits. create temporary_manifest was deleted during the merge and I have added it back in.