### PR TITLE
Remove some unused code in prepare.sh and address shellcheck concerns

### DIFF
--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 # trap any error, and mark it as a system failure.
-
 # Also cleans up TMPMANIFEST(set in create_temporary_manifest).
 trap 'rm -f "$TMPMANIFEST"; exit $SYSTEM_FAILURE_EXIT_CODE' ERR
 trap 'rm -f "$TMPMANIFEST"' EXIT
@@ -16,18 +15,6 @@ if [ -z "${WORKER_MEMORY-}" ]; then
     # Some jobs may fail with less than 512M, e.g., `npm i`
     WORKER_MEMORY="512M"
 fi
-
-create_temporary_varfile () {
-    # A less leak-prone way to share secrets into the worker which will not
-    # be able to parse VCAP_CONFIGURATION
-    TMPVARFILE=$(mktemp /tmp/gitlab-runner-worker-manifest.XXXXXXXXXX)
-
-    for v in RUNNER_NAME CACHE_TYPE CACHE_S3_SERVER_ADDRESS CACHE_S3_BUCKET_LOCATION CACHE_S3_BUCKET_NAME CACHE_S3_BUCKET_NAME CACHE_S3_ACCESS_KEY CACHE_S3_SECRET_KEY; do
-        echo "$v: \"$v\"" >> "$TMPVARFILE"
-    done
-
-    echo "[cf-driver] [DEBUG] Added $(wc -l "$TMPVARFILE") lines to $TMPVARFILE"
-}
 
 get_registry_credentials () {
     image_name="$1"
@@ -81,7 +68,6 @@ start_container () {
     if cf app --guid "$container_id" >/dev/null 2>/dev/null ; then
         echo '[cf-driver] Found old instance of runner executor, deleting'
         cf delete -f "$container_id"
-
     fi
 
     push_args=(
@@ -185,7 +171,6 @@ allow_access_to_service () {
         -o "$current_org" -s "$current_space" \
         --protocol "$protocol" --port "$ports"
 }
-
 
 allow_access_to_services () {
     container_id_base="$1"

--- a/runner/cf-driver/run.sh
+++ b/runner/cf-driver/run.sh
@@ -5,10 +5,10 @@
 currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${currentDir}/base.sh"
 
-printf "[cf-driver] Using SSH to connect to %s and run '%s' step\n" "$CONTAINER_ID" $2
+printf "[cf-driver] Using SSH to connect to %s and run '%s' step\n" "$CONTAINER_ID" "$2"
 
 # Add line below script shebang to source the /etc/profile
-sed -i '2isource /etc/profile \n' $1
+sed -i '2isource /etc/profile \n' "$1"
 
 if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
     # DANGER: There may be sensitive information in this output.
@@ -24,4 +24,4 @@ if ! cf ssh "$CONTAINER_ID" < "${1}"; then
     exit "$BUILD_FAILURE_EXIT_CODE"
 fi
 
-printf "[cf-driver] Completed SSH session with %s to run '%s' step\n" "$CONTAINER_ID" $2
+printf "[cf-driver] Completed SSH session with %s to run '%s' step\n" "$CONTAINER_ID" "$2"


### PR DESCRIPTION
* `create_temporary_varfile()` was unused in `prepare.sh`
* Adds a few quotes to make shellcheck happy