### PR TITLE
Pass .gitlab-ci.yml variables to services

### DIFF
--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -174,6 +174,8 @@ start_services () {
        return
     fi
 
+    # GitLab Runner creates JOB_RESPONSE_FILE to provide full job context
+    # See: https://docs.gitlab.com/runner/executors/custom.html#job-response
     services=$(jq -rc '.services[]' "$JOB_RESPONSE_FILE")
     job_vars=$(jq -r \
         '.variables[] | select((.key | test("^(?!(CI|GITLAB)_)"))) | [.key, .value] | @sh' \

--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -14,7 +14,7 @@ currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${currentDir}/base.sh" # Get variables from base.
 if [ -z "${WORKER_MEMORY-}" ]; then
     # Some jobs may fail with less than 512M, e.g., `npm i`
-    WORKER_MEMORY="512M"
+    WORKER_MEMORY="768M"
 fi
 
 get_registry_credentials () {
@@ -73,10 +73,11 @@ start_container () {
     fi
 
     push_args=(
-       "$container_id"
-       -f "$TMPMANIFEST"
-       -m "$WORKER_MEMORY"
-       --docker-image "$image_name"
+        "$container_id"
+        -f "$TMPMANIFEST"
+        -m "$WORKER_MEMORY"
+        -k "2GB"
+        --docker-image "$image_name"
     )
 
     local docker_user docker_pass


### PR DESCRIPTION
Also bumps memory & disk space because the rails-template instance's jobs needed more and there's no support for customizing those values yet.

Here's a somewhat contrived example job that would need these variables. Job variables are available to the worker and any services started by the job, `service.variables` are only available to that service and take priority over job level variables of the same name.

```yaml
test-setup-project:
  stage: setup
  needs: ["install-deps"]
  variables:
    RAILS_ENV: ci
    SECRET_KEY_BASE: not-actually-secret
    POSTGRES_PASSWORD: testpass123
  services:
    - name: postgres:15
      alias: pg
      variables:
        POSTGRES_PASSWORD: turtleturtle
  script:
    - *ruby_deps
    - *node_deps
    - export DATABASE_URL="postgres://postgres:turtleturtle@${CI_SERVICE_pg}:5432/rtci_test"
    - bin/rails db:create
    - bundle exec rake assets:precompile
    - bundle exec rake db:schema:load
```

Closes #33.