### PR TITLE
Add WORKER_DISK_SIZE tunable and pass through WORKER_MEMORY

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -24,6 +24,8 @@ applications:
       RUNNER_EXECUTOR: ((runner_executor))
       RUNNER_NAME: ((runner_name))
       OBJECT_STORE_INSTANCE: ((object_store_instance))
+      WORKER_MEMORY: ((worker_memory))
+      WORKER_DISK_SIZE: ((worker_disk_size))
       # Remaining runner configuration is generally static. In order to surface
       # the entire configuration input, we are using envvars for all of it.
       RUNNER_BUILDS_DIR: "/tmp/build"

--- a/runner/cf-driver/prepare.sh
+++ b/runner/cf-driver/prepare.sh
@@ -76,7 +76,7 @@ start_container () {
         "$container_id"
         -f "$TMPMANIFEST"
         -m "$WORKER_MEMORY"
-        -k "2GB"
+        -k "$WORKER_DISK_SIZE"
         --docker-image "$image_name"
     )
 

--- a/terraform/runner/main.tf
+++ b/terraform/runner/main.tf
@@ -5,57 +5,60 @@ locals {
 module "object_store_instance" {
   source = "github.com/GSA-TTS/terraform-cloudgov//s3?ref=v1.0.0"
 
-  cf_org_name      = var.cf_org_name
-  cf_space_name    = var.cf_space_name
-  name             = var.object_store_instance
-  s3_plan_name     = "basic-sandbox"
+  cf_org_name   = var.cf_org_name
+  cf_space_name = var.cf_space_name
+  name          = var.object_store_instance
+  s3_plan_name  = "basic-sandbox"
 }
 
 resource "cloudfoundry_app" "gitlab-runner" {
-    name = var.runner_app_name
-    space = data.cloudfoundry_space.space.id
-    path = "${path.module}/files/src.zip"
-    buildpacks = ["https://github.com/cloudfoundry/apt-buildpack", "binary_buildpack"]
-    instances = 1
-    command = "gitlab-runner run"
-    memory = var.runner_memory
-    health_check_type = "process"
-    
-    environment = {
-      # These are used by .profile
-      DEFAULT_JOB_IMAGE = var.default_job_image
-      # Remaining vars are used directly by gitlab-runner register
-      # See gitlab-runner register --help for available vars
-      CI_SERVER_TOKEN = var.ci_server_token
-      CI_SERVER_URL = var.ci_server_url
-      RUNNER_EXECUTOR = var.runner_executor
-      RUNNER_NAME = var.runner_name
-      # Remaining runner configuration is generally static. In order to surface
-      # the entire configuration input, we are using envvars for all of it.
-      RUNNER_BUILDS_DIR = "/tmp/build"
-      RUNNER_CACHE_DIR = "/tmp/cache"
-      CUSTOM_CLEANUP_EXEC = "/home/vcap/app/cf-driver/cleanup.sh"
-      CUSTOM_PREPARE_EXEC = "/home/vcap/app/cf-driver/prepare.sh"
-      CUSTOM_RUN_EXEC = "/home/vcap/app/cf-driver/run.sh"
-      REGISTER_NON_INTERACTIVE = true
-      # TODO - Add timeouts like CUSTOM_CLEANUP_EXEC_TIMEOUT
-      #
-      # DANGER: Do not set RUNNER_DEBUG to true without reading
-      # https://docs.gitlab.com/runner/faq/#enable-debug-logging-mode
-      # and ensuring job logs are removed to avoid leaking secrets.
-      RUNNER_DEBUG = "false"
-      OBJECT_STORE_INSTANCE = var.object_store_instance
-      DOCKER_HUB_USER = var.docker_hub_user
-      DOCKER_HUB_TOKEN = var.docker_hub_token
-    }
-    service_binding {
-        service_instance = data.cloudfoundry_service_instance.runner_service_account.id     
-    }
-    service_binding {
-        service_instance = data.cloudfoundry_service_instance.runner_object_store_instance.id     
-    }
-    
-    
+  name              = var.runner_app_name
+  space             = data.cloudfoundry_space.space.id
+  path              = "${path.module}/files/src.zip"
+  buildpacks        = ["https://github.com/cloudfoundry/apt-buildpack", "binary_buildpack"]
+  instances         = 1
+  command           = "gitlab-runner run"
+  memory            = var.runner_memory
+  health_check_type = "process"
 
-    
+  environment = {
+    # These are used by .profile
+    DEFAULT_JOB_IMAGE = var.default_job_image
+    # Following vars are used directly by gitlab-runner register
+    # See gitlab-runner register --help for available vars
+    CI_SERVER_TOKEN = var.ci_server_token
+    CI_SERVER_URL   = var.ci_server_url
+    RUNNER_EXECUTOR = var.runner_executor
+    RUNNER_NAME     = var.runner_name
+    # Following vars are for tuning worker defaults
+    WORKER_MEMORY    = var.worker_memory
+    WORKER_DISK_SIZE = var.worker_disk_size
+    # Remaining runner configuration is generally static. In order to surface
+    # the entire configuration input, we are using envvars for all of it.
+    RUNNER_BUILDS_DIR        = "/tmp/build"
+    RUNNER_CACHE_DIR         = "/tmp/cache"
+    CUSTOM_CLEANUP_EXEC      = "/home/vcap/app/cf-driver/cleanup.sh"
+    CUSTOM_PREPARE_EXEC      = "/home/vcap/app/cf-driver/prepare.sh"
+    CUSTOM_RUN_EXEC          = "/home/vcap/app/cf-driver/run.sh"
+    REGISTER_NON_INTERACTIVE = true
+    # TODO - Add timeouts like CUSTOM_CLEANUP_EXEC_TIMEOUT
+    #
+    # DANGER: Do not set RUNNER_DEBUG to true without reading
+    # https://docs.gitlab.com/runner/faq/#enable-debug-logging-mode
+    # and ensuring job logs are removed to avoid leaking secrets.
+    RUNNER_DEBUG          = "false"
+    OBJECT_STORE_INSTANCE = var.object_store_instance
+    DOCKER_HUB_USER       = var.docker_hub_user
+    DOCKER_HUB_TOKEN      = var.docker_hub_token
+  }
+  service_binding {
+    service_instance = data.cloudfoundry_service_instance.runner_service_account.id
+  }
+  service_binding {
+    service_instance = data.cloudfoundry_service_instance.runner_object_store_instance.id
+  }
+
+
+
+
 }

--- a/terraform/runner/var.tfvars
+++ b/terraform/runner/var.tfvars
@@ -1,14 +1,15 @@
-cf_org_name  = ""
-cf_space_name = ""
-ci_server_token = ""
-ci_server_url = "https://gitlab.com/"
+cf_org_name       = ""
+cf_space_name     = ""
+ci_server_token   = ""
+ci_server_url     = "https://gitlab.com/"
 default_job_image = "ubuntu:jammy"
 # Two executors are supported:
 #  custom - Runs jobs in new application instances, deleted after the run.
 #  shell - Runs jobs directly on the Runner manager.
-runner_executor = "custom"
-runner_name = ""
-runner_memory = 512
-worker_memory = "512M"
+runner_executor          = "custom"
+runner_name              = ""
+runner_memory            = 512
+worker_memory            = "512M"
+worker_disk_size         = "1G"
 service_account_instance = ""
-object_store_instance = ""
+object_store_instance    = ""

--- a/terraform/runner/variables.tf
+++ b/terraform/runner/variables.tf
@@ -52,13 +52,13 @@ variable "runner_name" {
 variable "runner_memory" {
   type        = number
   default     = 512
-  description = "Manager Runner Memory"
+  description = "Manager Runner Memory in MB"
 }
 
 variable "worker_memory" {
   type        = string
-  default     = "768M"
-  description = "Worker Memory"
+  default     = "512M"
+  description = "Worker Memory - Unit required (e.g. 512M or 2G)"
 }
 
 variable "worker_disk_size" {

--- a/terraform/runner/variables.tf
+++ b/terraform/runner/variables.tf
@@ -4,33 +4,33 @@ variable "cf_password" {
 variable "cf_user" {}
 
 variable "cf_org_name" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Cloud Foundry Organization"
 }
 
 variable "cf_space_name" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Cloud Foundry Space"
 }
 
 variable "ci_server_token" {
-  type = string
-  default = ""
-  sensitive = true
+  type        = string
+  default     = ""
+  sensitive   = true
   description = "Gitlab CI Server Token"
 }
 
 variable "ci_server_url" {
-  type = string
-  default = "https://gitlab.com/"
+  type        = string
+  default     = "https://gitlab.com/"
   description = "Gitlab URL"
 }
 
 variable "default_job_image" {
-  type = string
-  default = "ubuntu:jammy"
+  type        = string
+  default     = "ubuntu:jammy"
   description = "Default Job Image"
 }
 
@@ -38,38 +38,45 @@ variable "default_job_image" {
 #  custom - Runs jobs in new application instances, deleted after the run.
 #  shell - Runs jobs directly on the Runner manager.
 variable "runner_executor" {
-  type = string
-  default = "custom"
+  type        = string
+  default     = "custom"
   description = "Runner Executer"
 }
 
 variable "runner_name" {
-  type = string
-  default = "gitlab-runner"
+  type        = string
+  default     = "gitlab-runner"
   description = "Cloud Foundry Organization"
 }
 
 variable "runner_memory" {
-  type = number
-  default = 512
+  type        = number
+  default     = 512
   description = "Manager Runner Memory"
 }
 
 variable "worker_memory" {
-  type = string
-  default = ""
+  type        = string
+  default     = "768M"
   description = "Worker Memory"
 }
 
+variable "worker_disk_size" {
+  type        = string
+  default     = "1G"
+  description = "Worker Disk Size"
+}
+
+
 variable "service_account_instance" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Service Account Instance"
 }
 
 variable "object_store_instance" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "S3 Bucket for Gitlab Runner"
 }
 
@@ -80,20 +87,20 @@ variable "runner_service_bindings" {
   default     = []
 }
 
-variable "runner_app_name"{
-  type = string
-  default = "gitlab-runner"
+variable "runner_app_name" {
+  type        = string
+  default     = "gitlab-runner"
   description = "Cloud Foundry App Name"
 }
 
-variable "docker_hub_user"{
-  type = string
-  default = ""
+variable "docker_hub_user" {
+  type        = string
+  default     = ""
   description = "Docker Hub User"
 }
 
-variable "docker_hub_token"{
-  type = string
-  default = ""
+variable "docker_hub_token" {
+  type        = string
+  default     = ""
   description = "Docker Hub Token"
 }

--- a/vars.yml-example
+++ b/vars.yml-example
@@ -8,6 +8,7 @@ runner_executor: custom
 runner_name: my-runner-name
 runner_memory: 512M
 worker_memory: 512M
+worker_disk_size: 1G
 service_account_instance: my-service-account
 object_store_instance: my-brokered-bucket
 docker_hub_user: my-docker-user


### PR DESCRIPTION
## 🛠 Summary of changes

* Adds `WORKER_DISK_SIZE` tunable to set a default `-k SIZE` value for worker instances.
* Passes through `WORKER_MEMORY` from the manifest.
* `terraform fmt` updates - Sorry for the whitespace noise!

## 👀 Screenshots and Evidence

The default `WORKER_DISK_SIZE` value is `1G`. Below is a snippet of a job log after setting `worker_disk_size` to `2G` in my variable file and pushing.

![image](https://github.com/user-attachments/assets/a803ac56-6b4a-4c15-8dbc-c4f7e4f8f192)

