### PR TITLE
Add flags to keep GLR-W/S from being cleaned

### DIFF
--- a/runner/cf-driver/cleanup.sh
+++ b/runner/cf-driver/cleanup.sh
@@ -57,9 +57,13 @@ cleanup_services () {
     done
 }
 
-cleanup_services "$CONTAINER_ID" "$CUSTOM_ENV_CI_JOB_SERVICES"
+if [ -z "$CUSTOM_ENV_PRESERVE_SERVICES" ]; then
+    cleanup_services "$CONTAINER_ID" "$CUSTOM_ENV_CI_JOB_SERVICES"
+fi
 
-echo "[cf-driver] Deleting executor instance $CONTAINER_ID"
-cf delete -f "$CONTAINER_ID"
+if [ -z "$CUSTOM_ENV_PRESERVE_WORKER" ]; then
+    echo "[cf-driver] Deleting executor instance $CONTAINER_ID"
+    cf delete -f "$CONTAINER_ID"
+fi
 
 echo "[cf-driver] Cleanup completed for $CONTAINER_ID"


### PR DESCRIPTION
# 🎫 Addresses issue: #39

Flags to skip worker/service cleanup.

## 🛠 Summary of changes

When triggering a manual pipeline you can add these variables to cleanup of workers and/or services. The variables are `PRESERVE_WORKER`, and `PRESERVE_SERVICES` respectively. The `CUSTOM_ENV_…` gets appended by the runner.
