### PR TITLE
change sed sourcing lines to be more readable

### DIFF
--- a/runner/cf-driver/run.sh
+++ b/runner/cf-driver/run.sh
@@ -9,11 +9,12 @@ printf "[cf-driver] Using SSH to connect to %s and run '%s' step\n" "$CONTAINER_
 
 # Add line below script's shebang to source
 # /etc/profile, etc/environment & the $HOME/bin
-sed -i '' '1a\
+sed -e '1a\
 source /etc/profile
 source /etc/environment
 PATH="$HOME/bin:$PATH"
-' "$1"
+' "$1" >"$1.tmp"
+mv -- "$1.tmp" "$1"
 
 if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
     # DANGER: There may be sensitive information in this output.

--- a/runner/cf-driver/run.sh
+++ b/runner/cf-driver/run.sh
@@ -7,9 +7,13 @@ source "${currentDir}/base.sh"
 
 printf "[cf-driver] Using SSH to connect to %s and run '%s' step\n" "$CONTAINER_ID" "$2"
 
-# Add line below script shebang to source the /etc/profile
-sed -i '2isource /etc/environment\n' "$1"
-sed -i '2isource /etc/profile\n' "$1"
+# Add line below script's shebang to source
+# /etc/profile, etc/environment & the $HOME/bin
+sed -i '' '1a\
+source /etc/profile
+source /etc/environment
+PATH="$HOME/bin:$PATH"
+' "$1"
 
 if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
     # DANGER: There may be sensitive information in this output.


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: #52
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

Sed changes to GitLab's scripts in run.sh reads backwards.

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->

This uses a multi-line sed that reads more naturally

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
