### PR TITLE
added new lines to sed command according to stack overflow

### DIFF
--- a/runner/cf-driver/run.sh
+++ b/runner/cf-driver/run.sh
@@ -10,9 +10,9 @@ printf "[cf-driver] Using SSH to connect to %s and run '%s' step\n" "$CONTAINER_
 # Add line below script's shebang to source
 # /etc/profile, etc/environment & the $HOME/bin
 sed -e '1a\
-source /etc/profile
-source /etc/environment
-PATH="$HOME/bin:$PATH"
+source /etc/profile\
+source /etc/environment\
+PATH="$HOME/bin:$PATH"\
 ' "$1" >"$1.tmp"
 mv -- "$1.tmp" "$1"
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: #58 
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

# 🛠 Summary of changes
Added backslashes to each line of the multiline sed command.

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->


# 📜 Testing Plan

- Deploy Runner
- Use Runner in a Gitlab Pipeline
- The error "sed: -e expression 1, char 47: unterminated `s' command" is no longer displayed and replaced with expected output for each script step.


# 👀 Screenshots and Evidence
Before:
![Before](https://github.com/user-attachments/assets/4f9cf16e-ba15-40c5-8ec3-2a0645b6ec90 "Before")

After:
![Screenshot 2024-10-29 at 8 15 59 AM](https://github.com/user-attachments/assets/f2d9a3cf-3c43-4c69-9741-4107c921173e)
...(skipping installation output)
![Screenshot 2024-10-29 at 8 18 26 AM](https://github.com/user-attachments/assets/3f581b36-2872-4e29-9318-33398bdefd9a)


