### PR TITLE
Basic CI for Go CF Driver

### DIFF
--- a/.github/workflows/cf-driver-go.yml
+++ b/.github/workflows/cf-driver-go.yml
@@ -1,0 +1,29 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: "CF Driver: Go Build & Test"
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "./runner/cf-driver-go/go.mod"
+
+      - name: Format
+        run: go fmt ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...


### PR DESCRIPTION
# 🎫 Addresses issue: https://github.com/GSA-TTS/devtools-program/issues/171

Go Runner CI testing, linting, etc.

## 🛠 Summary of changes

Adds a very basic workflow to run `fmt`, `vet`, `build` & `test` on the Go cf-driver.
