### PR TITLE
Parallel job execution

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,7 @@ resource "cloudfoundry_app" "gitlab-runner-manager" {
     # https://docs.gitlab.com/runner/faq/#enable-debug-logging-mode
     # and ensuring job logs are removed to avoid leaking secrets.
     RUNNER_DEBUG              = "false"
+    RUNNER_CONCURRENCY        = var.runner_concurrency
     OBJECT_STORE_INSTANCE     = var.object_store_instance
     PROXY_CREDENTIAL_INSTANCE = cloudfoundry_service_instance.egress-proxy-credentials.name
     PROXY_APP_NAME            = var.egress_app_name

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "cloudfoundry_app" "gitlab-runner-manager" {
   path              = data.archive_file.src.output_path
   source_code_hash  = data.archive_file.src.output_base64sha256
   buildpacks        = ["https://github.com/cloudfoundry/apt-buildpack", "binary_buildpack"]
-  instances         = 1
+  instances         = var.manager_instances
   command           = "gitlab-runner run"
   memory            = var.manager_memory
   health_check_type = "process"

--- a/runner-manager/.profile
+++ b/runner-manager/.profile
@@ -81,6 +81,7 @@ if pgrep 'gitlab-runner' > /dev/null ; then
 else
     echo "Registering GitLab Runner with name $RUNNER_NAME"
     if gitlab-runner register; then
+        sed -e 's/concurrent = 1/concurrent = 10/' -i.bak .gitlab-runner/config.toml
         echo "GitLab Runner successfully registered"
     else
         exit_with_failure "GitLab Runner not registered"

--- a/runner-manager/.profile
+++ b/runner-manager/.profile
@@ -81,7 +81,7 @@ if pgrep 'gitlab-runner' > /dev/null ; then
 else
     echo "Registering GitLab Runner with name $RUNNER_NAME"
     if gitlab-runner register; then
-        sed -e 's/concurrent = 1/concurrent = 10/' -i.bak .gitlab-runner/config.toml
+        sed -e 's/concurrent = 1$/concurrent = 10/' -i.bak .gitlab-runner/config.toml
         echo "GitLab Runner successfully registered"
     else
         exit_with_failure "GitLab Runner not registered"

--- a/runner-manager/.profile
+++ b/runner-manager/.profile
@@ -81,7 +81,7 @@ if pgrep 'gitlab-runner' > /dev/null ; then
 else
     echo "Registering GitLab Runner with name $RUNNER_NAME"
     if gitlab-runner register; then
-        sed -e 's/concurrent = 1$/concurrent = 10/' -i.bak .gitlab-runner/config.toml
+        sed -e "s/concurrent = 1$/concurrent = $RUNNER_CONCURRENCY/" -i.bak .gitlab-runner/config.toml
         echo "GitLab Runner successfully registered"
     else
         exit_with_failure "GitLab Runner not registered"

--- a/sandbox-deploy/main.tf
+++ b/sandbox-deploy/main.tf
@@ -30,6 +30,7 @@ module "sandbox-runner" {
   ci_server_token         = var.ci_server_token
   docker_hub_user         = var.docker_hub_user
   docker_hub_token        = var.docker_hub_token
+  manager_instances       = 1
   developer_emails        = var.developer_emails
   worker_disk_size        = var.worker_disk_size
   worker_egress_allowlist = var.worker_egress_allowlist

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "runner_executor" {
   description = "Runner Executer"
 }
 
+variable "manager_instances" {
+  type        = number
+  default     = 2
+  description = "Number of manager instances to run"
+}
+
 variable "manager_memory" {
   type        = number
   default     = 512

--- a/variables.tf
+++ b/variables.tf
@@ -53,6 +53,12 @@ variable "manager_instances" {
   description = "Number of manager instances to run"
 }
 
+variable "runner_concurrency" {
+  type        = number
+  default     = 10
+  description = "The number of parallel jobs a single manager instance will support"
+}
+
 variable "manager_memory" {
   type        = number
   default     = 512


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: no issue
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

* update `concurrent` gitlab-runner global setting to 10 to allow a single manager to retrieve up to 10 concurrent job
* update default instances value to 2, to have a little more redundancy, while keeping the sandbox config to 1 for resource use


<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

## 👀 Screenshots and Evidence

nice speedup (though some of that on the fastest build is eliminating one of the sequential build jobs)

<img width="109" alt="Screenshot 2025-01-14 at 5 29 50 PM" src="https://github.com/user-attachments/assets/47177bd8-b5d8-4108-b0e9-0ed40febbbba" />
