### PR TITLE
Expand & update go driver names to be clearer, more memorable, and more consistent.

### DIFF
--- a/runner-manager/cfd/cloudgov/cf_adapter.go
+++ b/runner-manager/cfd/cloudgov/cf_adapter.go
@@ -1,4 +1,4 @@
-package cg
+package cloudgov
 
 import (
 	"context"
@@ -8,11 +8,11 @@ import (
 	"github.com/cloudfoundry/go-cfclient/v3/resource"
 )
 
-type GoCFClientAdapter struct {
+type CFClientAPI struct {
 	_con *client.Client
 }
 
-func (cf *GoCFClientAdapter) connect(url string, creds *Creds) error {
+func (cf *CFClientAPI) connect(url string, creds *Creds) error {
 	cfg, err := config.New(url, config.UserPassword(creds.Username, creds.Password))
 	if err != nil {
 		return err
@@ -27,7 +27,7 @@ func (cf *GoCFClientAdapter) connect(url string, creds *Creds) error {
 	return nil
 }
 
-func (cf *GoCFClientAdapter) conn() *client.Client {
+func (cf *CFClientAPI) conn() *client.Client {
 	if cf._con != nil {
 		return cf._con
 	}
@@ -42,7 +42,7 @@ func castApps(apps []*resource.App) []*App {
 	return Apps
 }
 
-func (cf *GoCFClientAdapter) getApps() ([]*App, error) {
+func (cf *CFClientAPI) appsGet() ([]*App, error) {
 	apps, err := cf.conn().Applications.ListAll(context.Background(), nil)
 	if err != nil {
 		return nil, err

--- a/runner-manager/cfd/cloudgov/cloudgov_integration_test.go
+++ b/runner-manager/cfd/cloudgov/cloudgov_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package cg_test
+package cloudgov_test
 
 import (
 	"bufio"
@@ -8,15 +8,15 @@ import (
 	"os"
 	"testing"
 
-	"github.com/GSA-TTS/gitlab-runner-cloudgov/runner/cfd/cg"
+	"github.com/GSA-TTS/gitlab-runner-cloudgov/runner/cfd/cloudgov"
 	"github.com/google/go-cmp/cmp"
 )
 
-func Test_CFAdapter_GetApps(t *testing.T) {
+func Test_CFAdapter_AppsGet(t *testing.T) {
 	var u, p, want string
 	var l int
 
-	path := "./testdata/.cg_creds"
+	path := "./testdata/.cloudgov_creds"
 	f, err := os.Open(path)
 	if err != nil {
 		t.Errorf(
@@ -60,17 +60,17 @@ scanning:
 		return
 	}
 
-	cgClient, err := cg.New(&cg.GoCFClientAdapter{}, &cg.Opts{
-		Creds: &cg.Creds{Username: u, Password: p},
+	cgClient, err := cloudgov.New(&cloudgov.CFClientAPI{}, &cloudgov.Opts{
+		Creds: &cloudgov.Creds{Username: u, Password: p},
 	})
 	if err != nil {
-		t.Errorf("Error getting cgClient = %v", err)
+		t.Errorf("Error getting cloudgovClient = %v", err)
 		return
 	}
 
-	apps, err := cgClient.GetApps()
+	apps, err := cgClient.AppsGet()
 	if err != nil {
-		t.Errorf("Error running GetApps() = %v", err)
+		t.Errorf("Error running AppsGet() = %v", err)
 		return
 	}
 

--- a/runner-manager/cfd/cloudgov/cloudgov_test.go
+++ b/runner-manager/cfd/cloudgov/cloudgov_test.go
@@ -18,7 +18,7 @@ type stubClientAPI struct {
 	FailConnect bool
 }
 
-func (a *stubClientAPI) getApps() (apps []*App, err error) {
+func (a *stubClientAPI) appsGet() (apps []*App, err error) {
 	if a.FailAppsGet {
 		return nil, errors.New("fail")
 	}

--- a/runner-manager/cfd/cloudgov/creds.go
+++ b/runner-manager/cfd/cloudgov/creds.go
@@ -1,4 +1,4 @@
-package cg
+package cloudgov
 
 import (
 	"encoding/json"

--- a/runner-manager/cfd/cloudgov/creds_test.go
+++ b/runner-manager/cfd/cloudgov/creds_test.go
@@ -1,6 +1,4 @@
-//go:build !integration
-
-package cg
+package cloudgov
 
 import (
 	"encoding/json"

--- a/runner-manager/cfd/cloudgov/testdata/.cloudgov_creds.sample
+++ b/runner-manager/cfd/cloudgov/testdata/.cloudgov_creds.sample
@@ -1,5 +1,5 @@
-# For simple integration test with cg_integration_test.go
-# 1. copy this file to `.cg_creds`
+# For simple integration test with cloudgov_integration_test.go
+# 1. copy this file to `.cloudgov_creds`
 # 2. replace with real credentials
 # 3. replace with real output
 username-1234-asdf


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: #80
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->

- `cg` > `cloudgov`
- `getApps` > `appsGet`
- `CloudI` > `ClientAPI` (and implementations now prefix this)
- `CredI` > `CredsGetter` (and implementations prefix)
- removed `//go:build !integration` from non-integration tests because it messes up `gopls`.
