### PR TITLE
Match egress rules to the ci_server_url in use

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   # the list of egress hosts to allow for runner-manager and always needed by runner workers
   devtools_egress_allowlist = [
     "*.fr.cloud.gov",                      # cf-cli calls from manager
-    "gsa-0.gitlab-dedicated.us",           # connections from both manager and runners
+    var.ci_server_url,                     # connections from both manager and runners
     "deb.debian.org",                      # debian runner dependencies install
     "*.ubuntu.com",                        # ubuntu runner dependencies install
     "dl-cdn.alpinelinux.org",              # alpine runner dependencies install
@@ -94,7 +94,7 @@ resource "cloudfoundry_app" "gitlab-runner-manager" {
     # Following vars are used directly by gitlab-runner register
     # See gitlab-runner register --help for available vars
     CI_SERVER_TOKEN = var.ci_server_token
-    CI_SERVER_URL   = var.ci_server_url
+    CI_SERVER_URL   = "https://${var.ci_server_url}"
     RUNNER_EXECUTOR = var.runner_executor
     RUNNER_NAME     = var.runner_manager_app_name
     # Following vars are for tuning worker defaults

--- a/sandbox-deploy/main.tf
+++ b/sandbox-deploy/main.tf
@@ -27,6 +27,7 @@ module "sandbox-runner" {
 
   cf_user                 = var.cf_user
   cf_space_prefix         = var.cf_space_prefix
+  ci_server_url           = "gsa-0.gitlab-dedicated.us"
   ci_server_token         = var.ci_server_token
   docker_hub_user         = var.docker_hub_user
   docker_hub_token        = var.docker_hub_token

--- a/tests/creation.tftest.hcl
+++ b/tests/creation.tftest.hcl
@@ -9,7 +9,7 @@ variables {
   cf_space_prefix         = "glr-cg-ci-tests"
   ci_server_token         = "fake-gdg-server-token"
   program_technologies    = ["ruby", "terraform"]
-  worker_egress_allowlist = ["api.example.gov", "gsa-0.gitlab-dedicated.us"]
+  worker_egress_allowlist = ["api.example.gov", "gsa.gitlab-dedicated.us"]
 }
 
 run "test-system-creation" {
@@ -100,7 +100,7 @@ run "test-system-creation" {
   assert {
     condition = local.proxy_allowlist == toset([
       "*.fr.cloud.gov",
-      "gsa-0.gitlab-dedicated.us",
+      "gsa.gitlab-dedicated.us",
       "deb.debian.org",
       "*.ubuntu.com",
       "dl-cdn.alpinelinux.org",

--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "ci_server_token" {
 
 variable "ci_server_url" {
   type        = string
-  default     = "https://gsa-0.gitlab-dedicated.us"
+  default     = "gsa.gitlab-dedicated.us"
   description = "Gitlab Dedicated for Government URL"
 }
 


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: #93 
<!--
Insert the issue number (or full link if the issue is in a different repo
-->
closes #93 

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->
* allow egress to ci_server_url
* default ci_server_url to the permanent GDG
* update sandbox-module to continue to point to sandbox GDG

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
