### PR TITLE
Limit org manager use

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: terraform validate
-        uses: dflook/terraform-validate@5f83a55d86936418dfc1d1f13d317ee8607b5ed5 #v1.47.0
+        uses: dflook/terraform-validate@a8236b6ed2ac088b60f65142d4933e6bfc9d71ec #v1.47.0
 
       - name: terraform fmt
-        uses: dflook/terraform-fmt-check@5f83a55d86936418dfc1d1f13d317ee8607b5ed5 #v1.47.0
+        uses: dflook/terraform-fmt-check@84e7351536952f1ba88f750a17e5bcfcf55dbd0e #v1.47.0
 
       - name: terraform test
-        uses: dflook/terraform-test@5f83a55d86936418dfc1d1f13d317ee8607b5ed5 #v1.47.0
+        uses: dflook/terraform-test@f203156ff9dbd7e7ae26e7dc2f7c8530262a88ff #v1.47.0
         env:
           CF_USER: ${{ secrets.CF_USER }}
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
@@ -37,6 +37,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: terraform validate
-        uses: dflook/terraform-validate@5f83a55d86936418dfc1d1f13d317ee8607b5ed5 #v1.47.0
+        uses: dflook/terraform-validate@a8236b6ed2ac088b60f65142d4933e6bfc9d71ec #v1.47.0
         with:
           path: sandbox-deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,8 @@ jobs:
         env:
           CF_USER: ${{ secrets.CF_USER }}
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-          TF_VAR_cf_user: ${{ secrets.CF_USER }}
+          TF_VAR_cf_org_manager: ${{ secrets.CF_USER }}
+          TF_VAR_cf_community_user: ${{ secrets.CF_USER }}
           TERRAFORM_PRE_RUN: |
             apt-get update
             apt-get install -y zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: terraform validate
-        uses: dflook/terraform-validate@v1
+        uses: dflook/terraform-validate@5f83a55d86936418dfc1d1f13d317ee8607b5ed5 #v1.47.0
 
       - name: terraform fmt
-        uses: dflook/terraform-fmt-check@v1
+        uses: dflook/terraform-fmt-check@5f83a55d86936418dfc1d1f13d317ee8607b5ed5 #v1.47.0
 
       - name: terraform test
-        uses: dflook/terraform-test@v1
+        uses: dflook/terraform-test@5f83a55d86936418dfc1d1f13d317ee8607b5ed5 #v1.47.0
         env:
           CF_USER: ${{ secrets.CF_USER }}
           CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
@@ -37,6 +37,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: terraform validate
-        uses: dflook/terraform-validate@v1
+        uses: dflook/terraform-validate@5f83a55d86936418dfc1d1f13d317ee8607b5ed5 #v1.47.0
         with:
           path: sandbox-deploy

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -6,4 +6,4 @@ if [ -z "$CF_USER" ] || [ -z "$CF_PASSWORD" ]; then
   exit 1
 fi
 
-TF_VAR_cf_user="$CF_USER" terraform test
+TF_VAR_cf_org_manager="$CF_USER" TF_VAR_cf_community_user="$CF_USER" terraform test

--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,8 @@ module "manager_space" {
   cf_org_name   = var.cf_org_name
   cf_space_name = "${var.cf_space_prefix}-manager"
   allow_ssh     = var.allow_ssh
-  deployers     = [var.cf_user]
-  developers    = var.developer_emails
+  deployers     = [var.cf_org_manager]
+  developers    = setunion(var.developer_emails, [var.cf_community_user])
 }
 
 # worker_space: cloud.gov space for running runner workers and runner services
@@ -36,7 +36,7 @@ module "worker_space" {
   cf_org_name          = var.cf_org_name
   cf_space_name        = "${var.cf_space_prefix}-workers"
   allow_ssh            = true # manager must be able to cf ssh into workers
-  deployers            = [var.cf_user]
+  deployers            = [var.cf_org_manager]
   developers           = var.developer_emails
   security_group_names = ["trusted_local_networks_egress"]
 }
@@ -142,8 +142,8 @@ module "egress_space" {
   cf_org_name          = var.cf_org_name
   cf_space_name        = "${var.cf_space_prefix}-egress"
   allow_ssh            = var.allow_ssh
-  deployers            = [var.cf_user]
-  developers           = var.developer_emails
+  deployers            = [var.cf_org_manager]
+  developers           = setunion(var.developer_emails, [var.cf_community_user])
   security_group_names = ["public_networks_egress"]
 }
 

--- a/sandbox-deploy/main.tf
+++ b/sandbox-deploy/main.tf
@@ -11,11 +11,8 @@ terraform {
     }
   }
 }
-provider "cloudfoundry" {
-  api_url  = "https://api.fr.cloud.gov"
-  user     = var.cf_user
-  password = var.cf_password
-}
+provider "cloudfoundry" {}
+
 provider "cloudfoundry-community" {
   api_url  = "https://api.fr.cloud.gov"
   user     = var.cf_user
@@ -25,7 +22,8 @@ provider "cloudfoundry-community" {
 module "sandbox-runner" {
   source = "../"
 
-  cf_user                 = var.cf_user
+  cf_org_manager          = var.cf_org_manager
+  cf_community_user       = var.cf_user
   cf_space_prefix         = var.cf_space_prefix
   ci_server_url           = "gsa-0.gitlab-dedicated.us"
   ci_server_token         = var.ci_server_token

--- a/sandbox-deploy/terraform.sh
+++ b/sandbox-deploy/terraform.sh
@@ -74,7 +74,6 @@ if [[ ! -f secrets.auto.tfvars ]]; then
   username=`echo "$creds" | jq -r '.username'`
   password=`echo "$creds" | jq -r '.password'`
 
-  cf set-org-role "$username" "$org" OrgManager
   cat > secrets.auto.tfvars << EOF
 # generated with terraform.sh, will be cleaned up by terraform.sh when destroying the entire sandbox
 #mgmt_space $mgmt_space

--- a/sandbox-deploy/variables.tf
+++ b/sandbox-deploy/variables.tf
@@ -1,9 +1,16 @@
+variable "cf_org_manager" {
+  type        = string
+  description = "The OrgManager developer email that is running the sandbox deploy"
+}
+
 variable "cf_user" {
-  type = string
+  type        = string
+  description = "A regular space developer to log into the community provider"
 }
 variable "cf_password" {
-  type      = string
-  sensitive = true
+  type        = string
+  sensitive   = true
+  description = "The password associated with cf_user to log into the community provider"
 }
 variable "cf_space_prefix" {
   type = string

--- a/sandbox-deploy/vars.tfvars-example
+++ b/sandbox-deploy/vars.tfvars-example
@@ -1,3 +1,4 @@
+cf_org_manager       = "your.email@gsa.gov"
 allow_ssh            = true
 cf_space_prefix      = ""
 ci_server_token      = ""

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,15 @@
-variable "cf_user" {
+variable "cf_org_manager" {
   type        = string
-  description = "The cloud.gov username that is running the root terraform module"
+  description = "The cloud.gov username that is running the root terraform module, must be an OrgManager"
+}
+
+variable "cf_community_user" {
+  type        = string
+  description = "The cloud.gov service-account username that is logged into the cloudfoundry-community provider"
 }
 
 variable "developer_emails" {
-  type        = list(string)
+  type        = set(string)
   description = "cloud.gov accounts to grant SpaceDeveloper access to the runner space and runner egress space"
   default     = []
 }


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: https://github.com/GSA-TTS/devtools-gitlab-terraform/issues/26
<!--
Insert the issue number (or full link if the issue is in a different repo
-->
There will also be changes in the devtools-gitlab-terraform repo before the whole issue can be closed.

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->
* Enable setting permissions so that we don't have to create new OrgManagers in the sandbox terraform.sh script.
* Once the community provider has been fully phased out we'll want to remove the new `cf_community_user` variable, which will also mean we can remove the need to create any service account in `sandbox/terraform.sh`

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
