### PR TITLE
Compatibility Improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/runner-manager/cf-driver/prepare.sh
+++ b/runner-manager/cf-driver/prepare.sh
@@ -10,14 +10,14 @@ TMPFILES=()
 
 # Prepare a runner executor application in CloudFoundry
 
-currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+currentDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source "${currentDir}/base.sh" # Get variables from base.
 if [ -z "${WORKER_MEMORY-}" ]; then
     # Some jobs may fail with less than 512M, e.g., `npm i`
     WORKER_MEMORY="768M"
 fi
 
-get_registry_credentials () {
+get_registry_credentials() {
     image_name="$1"
 
     # Note: the regex for non-docker image locations is not air-tight--
@@ -40,23 +40,23 @@ get_registry_credentials () {
     fi
 }
 
-create_temporary_manifest () {
+create_temporary_manifest() {
     # A less leak-prone way to share secrets into the worker which will not
     # be able to parse VCAP_CONFIGURATION
     TMPMANIFEST=$(mktemp /tmp/gitlab-runner-worker-manifest.XXXXXXXXXX)
     TMPFILES+=("$TMPMANIFEST")
     chmod 600 "$TMPMANIFEST"
-    cat "${currentDir}/worker-manifest.yml" > "$TMPMANIFEST"
+    cat "${currentDir}/worker-manifest.yml" >"$TMPMANIFEST"
 
     # Align additional environment variables with YAML at end of source manifest
     local padding="      "
 
     # Add any CI_SERVICE_x variables populated by start_service()
     for v in "${!CI_SERVICE_@}"; do
-        echo "${padding}${v}: \"${!v}\"" >> "$TMPMANIFEST"
+        echo "${padding}${v}: \"${!v}\"" >>"$TMPMANIFEST"
     done
 
-    echo "[cf-driver] [DEBUG] $(wc -l < "$TMPMANIFEST") lines in $TMPMANIFEST"
+    echo "[cf-driver] [DEBUG] $(wc -l <"$TMPMANIFEST") lines in $TMPMANIFEST"
 }
 
 setup_proxy_access() {
@@ -90,7 +90,7 @@ start_container () {
     container_id="$1"
     image_name="$CUSTOM_ENV_CI_JOB_IMAGE"
 
-    if cf app --guid "$container_id" >/dev/null 2>/dev/null ; then
+    if cf app --guid "$container_id" >/dev/null 2>/dev/null; then
         echo '[cf-driver] Found old instance of runner executor, deleting'
         cf delete -f "$container_id"
     fi
@@ -128,7 +128,7 @@ start_container () {
     fi
 
     local docker_user docker_pass
-    read -r docker_user docker_pass <<< "$(get_registry_credentials "$image_name")"
+    read -r docker_user docker_pass <<<"$(get_registry_credentials "$image_name")"
 
     if [ -z "${RUNNER_DEBUG-}" ] || [ "$RUNNER_DEBUG" != "true" ]; then
         push_args+=('--redact-env')
@@ -146,7 +146,7 @@ start_container () {
     setup_proxy_access "$CONTAINER_ID"
 }
 
-start_service () {
+start_service() {
     alias_name="$1"
     container_id="$2"
     image_name="$3"
@@ -162,7 +162,7 @@ start_service () {
         exit 1
     fi
 
-    if cf app --guid "$container_id" >/dev/null 2>/dev/null ; then
+    if cf app --guid "$container_id" >/dev/null 2>/dev/null; then
         echo '[cf-driver] Found old instance of runner service, deleting'
         cf delete -f "$container_id"
     fi
@@ -220,7 +220,7 @@ start_service () {
     fi
 
     local docker_user docker_pass
-    read -r docker_user docker_pass <<< "$(get_registry_credentials "$image_name")"
+    read -r docker_user docker_pass <<<"$(get_registry_credentials "$image_name")"
 
     if [ -n "$docker_user" ] && [ -n "$docker_pass" ]; then
         push_args+=('--docker-username' "${docker_user}")
@@ -235,13 +235,13 @@ start_service () {
     export "CI_SERVICE_${alias_name}"="${container_id}.apps.internal"
 }
 
-start_services () {
+start_services() {
     container_id_base="$1"
     ci_job_services="$2"
 
     if [ -z "$ci_job_services" ]; then
-       echo "[cf-driver] No services defined in ci_job_services - Skipping service startup"
-       return
+        echo "[cf-driver] No services defined in ci_job_services - Skipping service startup"
+        return
     fi
 
     # GitLab Runner creates JOB_RESPONSE_FILE to provide full job context
@@ -269,7 +269,7 @@ start_services () {
     done
 }
 
-allow_access_to_service () {
+allow_access_to_service() {
     source_app="$1"
     destination_service_app="$2"
 
@@ -282,13 +282,13 @@ allow_access_to_service () {
         --protocol "$protocol" --port "$ports"
 }
 
-allow_access_to_services () {
+allow_access_to_services() {
     container_id_base="$1"
     ci_job_services="$2"
 
     if [ -z "$ci_job_services" ]; then
-       echo "[cf-driver] No services defined in ci_job_services - Skipping service allowance"
-       return
+        echo "[cf-driver] No services defined in ci_job_services - Skipping service allowance"
+        return
     fi
 
     for l in $(echo "$ci_job_services" | jq -rc '.[]'); do
@@ -297,7 +297,7 @@ allow_access_to_services () {
     done
 }
 
-install_dependencies () {
+install_dependencies() {
     container_id="$1"
 
     # Build a command to try and install git and git-lfs on common distros.

--- a/runner-manager/cf-driver/prepare.sh
+++ b/runner-manager/cf-driver/prepare.sh
@@ -26,7 +26,7 @@ get_registry_credentials() {
     #       we're working with more a more robust set of language features
     #       and can better parse the image name.
 
-    if echo "$image_name" | grep -q "registry.gitlab.com"; then
+    if echo "$image_name" | grep -q "$CUSTOM_ENV_CI_REGISTRY"; then
         # Detect GitLab CR and use provided environment to authenticate
         echo "$CUSTOM_ENV_CI_REGISTRY_USER" "$CUSTOM_ENV_CI_REGISTRY_PASSWORD"
 

--- a/runner-manager/cf-driver/prepare.sh
+++ b/runner-manager/cf-driver/prepare.sh
@@ -79,7 +79,15 @@ setup_proxy_access() {
         mkdir -p /usr/local/share/ca-certificates && \
         cat /etc/cf-system-certificates/* > /usr/local/share/ca-certificates/cf-system-certificates.crt && \
         (command -v update-ca-certificates && update-ca-certificates) || \
-        ([ -f /etc/ssl/certs/ca-certificates.crt ] && cat /etc/cf-system-certificates/* >> /etc/ssl/certs/ca-certificates.crt) || \
+        ( \
+            [ -f /etc/ssl/certs/ca-certificates.crt ] && \
+            cat /etc/cf-system-certificates/* >> /etc/ssl/certs/ca-certificates.crt \
+        ) || \
+        ( \
+            [ -f /etc/ssl/cert.pem ] && \
+            cat /etc/cf-system-certificates/* >> /etc/ssl/cert.pem && \
+            ln -s /etc/ssl/cert.pem /etc/ssl/certs/ca-certificates.crt \
+        ) || \
         (echo "[cf-driver] Could not update system ca certificates. This may or may not be a problem depending on your base image." && exit 0)'
     cf_ssh "$container_id" \
         'source /etc/profile && \

--- a/runner-manager/cf-driver/prepare.sh
+++ b/runner-manager/cf-driver/prepare.sh
@@ -86,7 +86,7 @@ setup_proxy_access() {
         (command -v apt-get && echo "Acquire::http::Proxy \"$http_proxy\";" > /etc/apt/apt.conf.d/proxy.conf) || exit 0'
 }
 
-start_container () {
+start_container() {
     container_id="$1"
     image_name="$CUSTOM_ENV_CI_JOB_IMAGE"
 
@@ -117,14 +117,16 @@ start_container () {
     container_entrypoint=$(echo "$img_data" | jq -r '.entrypoint | select(.)')
     container_command=$(echo "$img_data" | jq -r '.command | select(.)')
 
+    push_args+=('-c')
     if [ -n "$container_entrypoint" ] || [ -n "$container_command" ]; then
-        push_args+=('-c')
         if [ -n "$container_entrypoint" ]; then
             push_args+=("${container_entrypoint[@]}")
         fi
         if [ -n "$container_command" ]; then
             push_args+=("${container_command[@]}")
         fi
+    else
+        push_args+=("/bin/sh")
     fi
 
     local docker_user docker_pass

--- a/runner-manager/cf-driver/run.sh
+++ b/runner-manager/cf-driver/run.sh
@@ -13,6 +13,7 @@ sed -e '1a\
 source /etc/profile\
 touch /etc/environment\
 source /etc/environment\
+source "$HOME/.glr-env"\
 PATH="$PATH:/usr/local/bin"\
 ' "$1" >"$1.tmp"
 mv -- "$1.tmp" "$1"

--- a/runner-manager/cf-driver/run.sh
+++ b/runner-manager/cf-driver/run.sh
@@ -2,7 +2,7 @@
 #
 # Run a step
 
-currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+currentDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 source "${currentDir}/base.sh"
 
 printf "[cf-driver] Using SSH to connect to %s and run '%s' step\n" "$CONTAINER_ID" "$2"
@@ -14,7 +14,7 @@ source /etc/profile\
 touch /etc/environment\
 source /etc/environment\
 PATH="$HOME/bin:$PATH"\
-' "$1" > "$1.tmp"
+' "$1" >"$1.tmp"
 mv -- "$1.tmp" "$1"
 
 if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
@@ -25,7 +25,7 @@ if [ -n "${RUNNER_DEBUG-}" ] && [ "$RUNNER_DEBUG" == "true" ]; then
     printf "\n=========\n[cf-driver] RUNNER_DEBUG: End command display\n"
 fi
 
-if ! cf_ssh "$CONTAINER_ID" < "${1}"; then
+if ! cf_ssh "$CONTAINER_ID" <"${1}"; then
     # Exit using the variable, to make the build as failure in GitLab
     # CI.
     exit "$BUILD_FAILURE_EXIT_CODE"

--- a/runner-manager/cf-driver/run.sh
+++ b/runner-manager/cf-driver/run.sh
@@ -13,7 +13,7 @@ sed -e '1a\
 source /etc/profile\
 touch /etc/environment\
 source /etc/environment\
-PATH="$HOME/bin:$PATH"\
+PATH="$PATH:/usr/local/bin"\
 ' "$1" >"$1.tmp"
 mv -- "$1.tmp" "$1"
 

--- a/runner-manager/cf-driver/worker-setup/.gitattributes
+++ b/runner-manager/cf-driver/worker-setup/.gitattributes
@@ -1,0 +1,2 @@
+tar filter=lfs diff=lfs merge=lfs -text
+bundle/** filter=lfs diff=lfs merge=lfs -text

--- a/runner-manager/cf-driver/worker-setup/.gitignore
+++ b/runner-manager/cf-driver/worker-setup/.gitignore
@@ -1,3 +1,1 @@
-bundle/
-tar
-*.tgz
+bundle.tgz

--- a/runner-manager/cf-driver/worker-setup/.gitignore
+++ b/runner-manager/cf-driver/worker-setup/.gitignore
@@ -1,0 +1,3 @@
+bundle/
+tar
+*.tgz

--- a/runner-manager/cf-driver/worker-setup/README.md
+++ b/runner-manager/cf-driver/worker-setup/README.md
@@ -1,0 +1,33 @@
+# Worker Setup
+
+The worker setup requires a number of standalone binaries, some packaged in
+tarballs. These compiled assets are not currently version controlled or checked
+into LFS because we have not yet established any kind of real pipeline for them.
+Probably I will check them into LFS before this gets merged to main.
+
+## Assumed directory structure
+
+```text
+├── bundle
+│   ├── bin
+│   │   ├── git-lfs
+│   │   └── gitlab-runner-helper
+│   └── git.tgz
+└── tar
+```
+
+## bundle
+
+This will be tar-balled into `bundle.tgz` and transferred to the workers.
+
+### bin/git-lfs and bin/gitlab-runner-helper
+
+These are both standalone Go binaries downloaded manually from the package maintainers.
+
+### git.tgz
+
+Tarball of a standalone git packaged by DevTools.
+
+## tar
+
+Standalone `tar` packaged by DevTools, used to unpack `bundle.tgz` and then `git.tgz`.

--- a/runner-manager/cf-driver/worker-setup/README.md
+++ b/runner-manager/cf-driver/worker-setup/README.md
@@ -1,9 +1,8 @@
 # Worker Setup
 
 The worker setup requires a number of standalone binaries, some packaged in
-tarballs. These compiled assets are not currently version controlled or checked
-into LFS because we have not yet established any kind of real pipeline for them.
-Probably I will check them into LFS before this gets merged to main.
+tarballs. Creating the bundle is currently a manual process. Binaries and the git
+tarball should be checked into git-lfs.
 
 ## Assumed directory structure
 

--- a/runner-manager/cf-driver/worker-setup/bundle/bin/git-lfs
+++ b/runner-manager/cf-driver/worker-setup/bundle/bin/git-lfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b7c763bf72653f5b42a90ec0f93b5f14c2d62e67bf297a8e8eea1703100ef3a
+size 12218520

--- a/runner-manager/cf-driver/worker-setup/bundle/bin/gitlab-runner
+++ b/runner-manager/cf-driver/worker-setup/bundle/bin/gitlab-runner
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd8bb3aa55bf171f2e29e11dd3c7173c06ec22ab69638d75b6013124919d23a9
+size 62162054

--- a/runner-manager/cf-driver/worker-setup/bundle/git.tgz
+++ b/runner-manager/cf-driver/worker-setup/bundle/git.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f09d42cce7e454dc0a5e95db836654d11e1e231b2c17d1cc99e365cde62604e
+size 20846407

--- a/runner-manager/cf-driver/worker-setup/tar
+++ b/runner-manager/cf-driver/worker-setup/tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd9557e5c85aefbae5b150719b44751abc8bfb2893d359595a6b8e98d7f9f853
+size 1820824


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: https://github.com/GSA-TTS/devtools-program/issues/251
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

This grows compatibility of the bash driver for a wider range of images. Still to come is an attempt at supporting GitLab's DAST and some kind of more proper pipeline for the static binaries.

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->

- Added an `.editorconfig` for `sh` files and let `shfmt` format what I was working on
    - I can take this out if people don't like it, it just makes editing a little easier for me.
- Use env var to detect when image is on instance registry and requires credentials
- Use `/bin/sh` as the default worker container entrypoint, fixes healthcheck issues w/ images that wouldn't otherwise clear `health-check-type: process`.
- Add `/usr/local/bin` to path added in `run.sh`, fixes an issue with GitLab dependency scanner template.
- Update `/etc/ssl/cert.pem` when found in stead of `/etc/ssl/certs/ca-certificates.crt`.
- Bundle dependencies as static binaries and cat them into workers over ssh, replacing previous dep install process using package managers.

## 📜 Testing Plan

This project on GDG uses some of the GitLab templates and is set up with this version of the runner. But you could deploy your own instance of this using the `./sandbox-deploy` terraform, and test with some GitLab templates.

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
