### PR TITLE
Zjr/egress updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ resource "cloudfoundry_app" "gitlab-runner-manager" {
     # https://docs.gitlab.com/runner/faq/#enable-debug-logging-mode
     # and ensuring job logs are removed to avoid leaking secrets.
     RUNNER_DEBUG                 = "false"
-    ALLOWED_DEBUG_USERS          = join(" ", var.developer_emails)
+    RUNNER_DEBUG_USERS           = join(" ", var.developer_emails)
     CUSTOM_ENV_PRESERVE_WORKER   = "false"
     CUSTOM_ENV_PRESERVE_SERVICES = "false"
   }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,13 @@ locals {
     "deb.debian.org",         # debian runner dependencies install
     "*.ubuntu.com",           # ubuntu runner dependencies install
     "dl-cdn.alpinelinux.org", # alpine runner dependencies install
-    "*.fedoraproject.org"     # fedora runner dependencies install
+    "*.fedoraproject.org",    # fedora runner dependencies install
+    # common container registries
+    "*.gcr.io",
+    "*.ghcr.io",
+    "*.docker.io",
+    "*.docker.com",
+    "registry.gsa.gitlab-dedicated.us" # our own container registry
   ]
   technology_allowlist = flatten([for t in var.program_technologies : local.allowlist_map[t]])
   proxy_allowlist      = setunion(local.devtools_egress_allowlist, var.worker_egress_allowlist, local.technology_allowlist)

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "cloudfoundry_service_credential_binding" "runner-service-account-key" 
 locals {
   sa_bot_credentials = jsondecode(data.cloudfoundry_service_credential_binding.runner-service-account-key.credential_bindings.0.credential_binding).credentials
   sa_cf_username     = nonsensitive(local.sa_bot_credentials.username)
-  sa_cf_password     = local.sa_bot_credentials.password
+  sa_cf_password     = sensitive(local.sa_bot_credentials.password)
 }
 
 # gitlab-runner-manager: the actual runner manager app

--- a/runner-manager/cf-driver/base.sh
+++ b/runner-manager/cf-driver/base.sh
@@ -16,7 +16,7 @@ fi
 if [ "$RUNNER_DEBUG" == "true" ]; then
     debug_allowed="false"
 
-    for email in $ALLOWED_DEBUG_USERS; do
+    for email in $RUNNER_DEBUG_USERS; do
         if [ "$email" == "${CUSTOM_ENV_GITLAB_USER_EMAIL}" ]; then
             debug_allowed="true"
             break

--- a/runner-manager/cf-driver/run.sh
+++ b/runner-manager/cf-driver/run.sh
@@ -23,7 +23,7 @@ mv -- "$1.tmp" "$1"
 if [ "$RUNNER_DEBUG" == "true" ]; then
     # turn on xtrace after eval so we don't get double output
     # -- this is very similar to how CI_DEBUG_TRACE though it may do more
-    sed -e 's/eval $'\''export/eval $'\''set -o xtrace\nexport/' "$1" >"$1.tmp"
+    sed -e 's/eval $'\''/eval $'\''set -o xtrace\n/' "$1" >"$1.tmp"
     mv -- "$1.tmp" "$1"
 
     # Skip cleanup to aid postmortem

--- a/tests/creation.tftest.hcl
+++ b/tests/creation.tftest.hcl
@@ -101,7 +101,12 @@ run "test-system-creation" {
       "objects.githubusercontent.com",
       "*.releases.hashicorp.com",
       "registry.terraform.io",
-      "sts.us-gov-west-1.amazonaws.com"
+      "sts.us-gov-west-1.amazonaws.com",
+      "*.gcr.io",
+      "*.ghcr.io",
+      "*.docker.io",
+      "*.docker.com",
+      "registry.gsa.gitlab-dedicated.us"
     ])
     error_message = "The egress allowlist contains manager, technology, and worker entries"
   }


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Closes #106 
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

Adds container registries to the default egress allowlist so that customers can use them to build and publish images with kaniko. I'm a bit unsure of adding all these!

In regards to #106, the last thing I had needed validating GitLab's canned jobs was `gitlab.com` which the gemnasium dep scanner uses to get it's database. It seems like all of gitlab might be too wide for this and it could make more sense for us to pull a mirror or setup some kind of proxying?

Also includes a debugging fix, a nitpicky name change, and the explicit marking of sa_cf_password as sensitive.
<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
