### PR TITLE
compile domain regex only once

### DIFF
--- a/runner-manager/cfd/cmd/drive/get_job_config.go
+++ b/runner-manager/cfd/cmd/drive/get_job_config.go
@@ -68,6 +68,9 @@ type CIVar struct {
 	Value string
 }
 
+// match images w/ docker domain, or no domain (i.e. docker by default)
+var domainRegex = regexp.MustCompile(`^((registry-\d+|index)?\.?docker\.io\/|[^.]*(:|$))`)
+
 type VcapAppData struct {
 	CFApi     string `json:"cf_api"`
 	OrgID     string `json:"org_id"`
@@ -197,14 +200,11 @@ func (cfg *JobConfig) processImage(img Image, m *cloudgov.AppManifest) {
 	if img.Name != "" {
 		m.Docker.Image = img.Name
 
-		// match images w/ docker domain, or no domain (i.e. docker by default)
-		re := regexp.MustCompile(`^((registry-\d+|index)?\.?docker\.io\/|[^.]*(:|$))`)
-
 		// TODO: #95
 		if strings.Contains(img.Name, "registry.gitlab.com") {
 			m.Docker.Username = cfg.CIRegistryUser
 			m.Docker.Password = cfg.CIRegistryPass
-		} else if re.FindString(img.Name) != "" {
+		} else if domainRegex.FindString(img.Name) != "" {
 			m.Docker.Username = cfg.DockerHubUser
 			m.Docker.Password = cfg.DockerHubToken
 		}


### PR DESCRIPTION
## 🛠 Summary of changes

this PR moves the regex in `processImage` outside of the function, which should reduce the amount of compilations per each service. testing from someone with cloud.gov access is definitely needed, but I benchmarked the external invocation at `832.2 ns/op` vs. `12893 ns/op` for the existing code on a Ryzen 5 2600