### PR TITLE
Ensure spaces exist before creating creds services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -209,6 +209,7 @@ resource "cloudfoundry_service_instance" "manager-egress-credentials" {
     domain      = module.egress_proxy.domain
     http_port   = module.egress_proxy.http_port
   })
+  depends_on = [module.manager_space]
 }
 moved {
   from = cloudfoundry_service_instance.egress-proxy-credentials
@@ -224,4 +225,5 @@ resource "cloudfoundry_service_instance" "worker-egress-credentials" {
   credentials = jsonencode({
     http_uri = module.egress_proxy.http_proxy["wsr-worker"]
   })
+  depends_on = [module.worker_space]
 }


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: no issue
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->
* ensures the space and space roles have been fully created before attempting to create the user-provided credential services
* this is probably only a problem with the weird way I just ran it, where I manually deleted the worker space after a bunch of `PRESERVE_WORKER` runs, and then tried to recreate just that space, but it's nice to fix for that case too

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
